### PR TITLE
feat(marks): Add Matric Marks schema with School and SchoolPerformance entities

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-ef": {
-      "version": "10.0.5",
+      "version": "10.0.9",
       "commands": [
         "dotnet-ef"
       ],

--- a/docs/sessions/2026-06-14-matric-marks-schema.md
+++ b/docs/sessions/2026-06-14-matric-marks-schema.md
@@ -1,0 +1,70 @@
+# Matric Marks Schema
+
+**Date:** 2026-06-14
+**Branch:** `feat/matric-marks-schema`
+**Ticket:** MATRD-2
+
+## Summary
+
+Created the database schema for matric (NSC) school performance data. This replaces the mock data in `DashboardService` with real domain entities backed by the `marks` schema in PostgreSQL.
+
+## Changes
+
+### Domain Layer (`MatricDasbhoard.Domain.Entities`)
+
+- **`School.cs`** — Domain entity for schools/matric examination centres. Fields: Province, DistrictName, EmisNumber (unique), CentreNumber, CentreName, Quintile. Extends `BaseEntity`. Has a `Performances` navigation collection.
+
+- **`SchoolPerformance.cs`** — Yearly NSC performance data for a school. Fields: SchoolId (FK), Year, ProgressedNumber, TotalWrote, TotalAchieved, PercentAchieved. Unique constraint on (SchoolId, Year). Extends `BaseEntity`.
+
+### Infrastructure Layer
+
+- **`Features/Marks/Configurations/SchoolConfiguration.cs`** — EF Core config: `marks.Schools` table with unique index on `EmisNumber`, indexes on `Province` and `DistrictName`, cascade delete to performances.
+
+- **`Features/Marks/Configurations/SchoolPerformanceConfiguration.cs`** — EF Core config: `marks.SchoolPerformances` table with unique composite index on `(SchoolId, Year)`, index on `Year`, decimal precision 5,1 for `PercentAchieved`.
+
+- **`Persistence/MatricDasbhoardDbContext.cs`** — Added `DbSet<School>` and `DbSet<SchoolPerformance>`.
+
+- **`Persistence/Migrations/20260614103518_AddMatricMarksSchema.cs`** — Migration creating `marks` schema, `Schools` and `SchoolPerformances` tables, indexes, and FK.
+
+### Other
+
+- **`.config/dotnet-tools.json`** — Updated `dotnet-ef` from 10.0.5 to 10.0.9.
+
+## Data Model
+
+```
+Schools (marks schema)
+├── Id (Guid, PK)
+├── Province (varchar 100)
+├── DistrictName (varchar 200)
+├── EmisNumber (varchar 20, unique)
+├── CentreNumber (varchar 20)
+├── CentreName (varchar 500)
+├── Quintile (int)
+└── [BaseEntity audit fields]
+
+SchoolPerformances (marks schema)
+├── Id (Guid, PK)
+├── SchoolId (Guid, FK → Schools)
+├── Year (int)
+├── ProgressedNumber (int)
+├── TotalWrote (int)
+├── TotalAchieved (int)
+├── PercentAchieved (decimal 5,1)
+├── UNIQUE(SchoolId, Year)
+└── [BaseEntity audit fields]
+```
+
+## Verification
+
+- `dotnet build` — 0 errors
+- `dotnet test` — Unit: 97/97 passed. Architecture: 10/10 passed. Component: 541/541 passed. (API tests have pre-existing failures unrelated to these changes.)
+
+## CSV Data
+
+The source data file `2024_nsc_school_performance_report.csv` (6,922 rows) is at the project root. It contains school-level NSC performance data for 2022–2024 from the Department of Basic Education. A data import mechanism will be implemented separately.
+
+## Notes
+
+- Schema uses `marks` namespace to keep domain data separate from auth/infra tables.
+- The `DashboardService` currently returns mock data — a follow-up PR should replace it with real EF queries against these entities and import the CSV.

--- a/src/backend/MatricDasbhoard.Domain/Entities/School.cs
+++ b/src/backend/MatricDasbhoard.Domain/Entities/School.cs
@@ -1,0 +1,78 @@
+namespace MatricDasbhoard.Domain.Entities;
+
+/// <summary>
+/// Represents a school that participates in NSC matric examinations.
+/// Data sourced from the Department of Basic Education's annual NSC school performance report.
+/// </summary>
+public sealed class School : BaseEntity
+{
+    /// <summary>
+    /// Gets the province where the school is located (e.g. "EASTERN CAPE", "GAUTENG").
+    /// </summary>
+    public string Province { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Gets the education district or circuit name.
+    /// </summary>
+    public string DistrictName { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Gets the EMIS (Education Management Information System) number — a unique school identifier.
+    /// </summary>
+    public string EmisNumber { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Gets the examination centre number assigned by the Department of Basic Education.
+    /// </summary>
+    public string CentreNumber { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Gets the official name of the school or examination centre.
+    /// </summary>
+    public string CentreName { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Gets the school quintile (1–5), a socio-economic classification used by the DBE for funding allocation.
+    /// Quintile 1 is the poorest, Quintile 5 is the wealthiest.
+    /// </summary>
+    public int Quintile { get; private set; }
+
+    /// <summary>
+    /// Gets the yearly performance records for this school.
+    /// </summary>
+    public ICollection<SchoolPerformance> Performances { get; private set; } = new List<SchoolPerformance>();
+
+    /// <summary>
+    /// Required by EF Core.
+    /// </summary>
+    private School()
+    {
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="School"/> instance with the specified details.
+    /// </summary>
+    public School(
+        string province,
+        string districtName,
+        string emisNumber,
+        string centreNumber,
+        string centreName,
+        int quintile)
+    {
+        Province = province;
+        DistrictName = districtName;
+        EmisNumber = emisNumber;
+        CentreNumber = centreNumber;
+        CentreName = centreName;
+        Quintile = quintile;
+    }
+
+    /// <summary>
+    /// Adds a yearly performance record to this school.
+    /// </summary>
+    public void AddPerformance(SchoolPerformance performance)
+    {
+        Performances.Add(performance);
+    }
+}

--- a/src/backend/MatricDasbhoard.Domain/Entities/SchoolPerformance.cs
+++ b/src/backend/MatricDasbhoard.Domain/Entities/SchoolPerformance.cs
@@ -1,0 +1,77 @@
+namespace MatricDasbhoard.Domain.Entities;
+
+/// <summary>
+/// Represents a school's NSC matric performance data for a single academic year.
+/// Each record captures the number of learners who wrote, achieved, and the pass percentage.
+/// </summary>
+public sealed class SchoolPerformance : BaseEntity
+{
+    /// <summary>
+    /// Gets the unique identifier of the school this performance record belongs to.
+    /// </summary>
+    public Guid SchoolId { get; private set; }
+
+    /// <summary>
+    /// Gets the school this performance record belongs to.
+    /// </summary>
+    public School School { get; private set; } = null!;
+
+    /// <summary>
+    /// Gets the academic year (e.g., 2024).
+    /// </summary>
+    public int Year { get; private set; }
+
+    /// <summary>
+    /// Gets the number of progressed learners who wrote the NSC exams.
+    /// Progressed learners are those who moved from Grade 11 to Grade 12 without meeting the promotion requirements.
+    /// </summary>
+    public int ProgressedNumber { get; private set; }
+
+    /// <summary>
+    /// Gets the total number of learners who wrote the NSC exams.
+    /// </summary>
+    public int TotalWrote { get; private set; }
+
+    /// <summary>
+    /// Gets the total number of learners who achieved (passed) the NSC exams.
+    /// </summary>
+    public int TotalAchieved { get; private set; }
+
+    /// <summary>
+    /// Gets the pass percentage (total achieved / total wrote * 100).
+    /// </summary>
+    public decimal PercentAchieved { get; private set; }
+
+    /// <summary>
+    /// Required by EF Core.
+    /// </summary>
+    private SchoolPerformance()
+    {
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="SchoolPerformance"/> instance.
+    /// </summary>
+    public SchoolPerformance(
+        int year,
+        int progressedNumber,
+        int totalWrote,
+        int totalAchieved,
+        decimal percentAchieved)
+    {
+        Year = year;
+        ProgressedNumber = progressedNumber;
+        TotalWrote = totalWrote;
+        TotalAchieved = totalAchieved;
+        PercentAchieved = percentAchieved;
+    }
+
+    /// <summary>
+    /// Associates this performance record with a school.
+    /// </summary>
+    internal void SetSchool(School school)
+    {
+        School = school;
+        SchoolId = school.Id;
+    }
+}

--- a/src/backend/MatricDasbhoard.Infrastructure/Features/Marks/Configurations/SchoolConfiguration.cs
+++ b/src/backend/MatricDasbhoard.Infrastructure/Features/Marks/Configurations/SchoolConfiguration.cs
@@ -1,0 +1,59 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MatricDasbhoard.Domain.Entities;
+using MatricDasbhoard.Infrastructure.Persistence.Configurations;
+
+namespace MatricDasbhoard.Infrastructure.Features.Marks.Configurations;
+
+/// <summary>
+/// EF Core configuration for the <see cref="School"/> entity in the <c>marks</c> schema.
+/// </summary>
+internal sealed class SchoolConfiguration : BaseEntityConfiguration<School>
+{
+    /// <inheritdoc />
+    protected override void ConfigureEntity(EntityTypeBuilder<School> builder)
+    {
+        builder.ToTable("Schools", "marks");
+
+        builder.Property(e => e.Province)
+            .IsRequired()
+            .HasMaxLength(100);
+
+        builder.Property(e => e.DistrictName)
+            .IsRequired()
+            .HasMaxLength(200);
+
+        builder.Property(e => e.EmisNumber)
+            .IsRequired()
+            .HasMaxLength(20);
+
+        builder.Property(e => e.CentreNumber)
+            .IsRequired()
+            .HasMaxLength(20);
+
+        builder.Property(e => e.CentreName)
+            .IsRequired()
+            .HasMaxLength(500);
+
+        builder.Property(e => e.Quintile)
+            .IsRequired();
+
+        // EMIS number is a stable unique identifier for each school
+        builder.HasIndex(e => e.EmisNumber)
+            .IsUnique()
+            .HasDatabaseName("IX_Schools_EmisNumber");
+
+        // Indexes for common filter/sort paths
+        builder.HasIndex(e => e.Province)
+            .HasDatabaseName("IX_Schools_Province");
+
+        builder.HasIndex(e => e.DistrictName)
+            .HasDatabaseName("IX_Schools_DistrictName");
+
+        // Navigation: a school has many performance records
+        builder.HasMany(e => e.Performances)
+            .WithOne(e => e.School)
+            .HasForeignKey(e => e.SchoolId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/backend/MatricDasbhoard.Infrastructure/Features/Marks/Configurations/SchoolPerformanceConfiguration.cs
+++ b/src/backend/MatricDasbhoard.Infrastructure/Features/Marks/Configurations/SchoolPerformanceConfiguration.cs
@@ -1,0 +1,43 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MatricDasbhoard.Domain.Entities;
+using MatricDasbhoard.Infrastructure.Persistence.Configurations;
+
+namespace MatricDasbhoard.Infrastructure.Features.Marks.Configurations;
+
+/// <summary>
+/// EF Core configuration for the <see cref="SchoolPerformance"/> entity in the <c>marks</c> schema.
+/// </summary>
+internal sealed class SchoolPerformanceConfiguration : BaseEntityConfiguration<SchoolPerformance>
+{
+    /// <inheritdoc />
+    protected override void ConfigureEntity(EntityTypeBuilder<SchoolPerformance> builder)
+    {
+        builder.ToTable("SchoolPerformances", "marks");
+
+        builder.Property(e => e.Year)
+            .IsRequired();
+
+        builder.Property(e => e.ProgressedNumber)
+            .IsRequired();
+
+        builder.Property(e => e.TotalWrote)
+            .IsRequired();
+
+        builder.Property(e => e.TotalAchieved)
+            .IsRequired();
+
+        builder.Property(e => e.PercentAchieved)
+            .IsRequired()
+            .HasPrecision(5, 1);
+
+        // One performance record per school per year
+        builder.HasIndex(e => new { e.SchoolId, e.Year })
+            .IsUnique()
+            .HasDatabaseName("IX_SchoolPerformances_SchoolId_Year");
+
+        // Index for filtering by year
+        builder.HasIndex(e => e.Year)
+            .HasDatabaseName("IX_SchoolPerformances_Year");
+    }
+}

--- a/src/backend/MatricDasbhoard.Infrastructure/Persistence/MatricDasbhoardDbContext.cs
+++ b/src/backend/MatricDasbhoard.Infrastructure/Persistence/MatricDasbhoardDbContext.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
+using MatricDasbhoard.Domain.Entities;
 using MatricDasbhoard.Infrastructure.Features.Audit.Models;
 using MatricDasbhoard.Infrastructure.Features.Authentication.Models;
 using MatricDasbhoard.Infrastructure.Features.Jobs.Models;
@@ -47,6 +48,16 @@ internal class MatricDasbhoardDbContext(DbContextOptions<MatricDasbhoardDbContex
     /// Gets or sets the external provider configurations for admin-managed OAuth credentials.
     /// </summary>
     public DbSet<ExternalProviderConfig> ExternalProviderConfigs { get; set; }
+
+    /// <summary>
+    /// Gets or sets the schools table for matric examination centres.
+    /// </summary>
+    public DbSet<School> Schools { get; set; }
+
+    /// <summary>
+    /// Gets or sets the school performance records table for yearly NSC results.
+    /// </summary>
+    public DbSet<SchoolPerformance> SchoolPerformances { get; set; }
 
     /// <summary>
     /// Configures the model by applying all entity configurations from this assembly

--- a/src/backend/MatricDasbhoard.Infrastructure/Persistence/Migrations/20260614103518_AddMatricMarksSchema.Designer.cs
+++ b/src/backend/MatricDasbhoard.Infrastructure/Persistence/Migrations/20260614103518_AddMatricMarksSchema.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MatricDasbhoard.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MatricDasbhoard.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(MatricDasbhoardDbContext))]
-    partial class MatricDasbhoardDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260614103518_AddMatricMarksSchema")]
+    partial class AddMatricMarksSchema
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/backend/MatricDasbhoard.Infrastructure/Persistence/Migrations/20260614103518_AddMatricMarksSchema.cs
+++ b/src/backend/MatricDasbhoard.Infrastructure/Persistence/Migrations/20260614103518_AddMatricMarksSchema.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MatricDasbhoard.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMatricMarksSchema : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.EnsureSchema(
+                name: "marks");
+
+            migrationBuilder.CreateTable(
+                name: "Schools",
+                schema: "marks",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Province = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    DistrictName = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    EmisNumber = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    CentreNumber = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    CentreName = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    Quintile = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: true),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    UpdatedBy = table.Column<Guid>(type: "uuid", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    DeletedBy = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Schools", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "SchoolPerformances",
+                schema: "marks",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    SchoolId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Year = table.Column<int>(type: "integer", nullable: false),
+                    ProgressedNumber = table.Column<int>(type: "integer", nullable: false),
+                    TotalWrote = table.Column<int>(type: "integer", nullable: false),
+                    TotalAchieved = table.Column<int>(type: "integer", nullable: false),
+                    PercentAchieved = table.Column<decimal>(type: "numeric(5,1)", precision: 5, scale: 1, nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: true),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    UpdatedBy = table.Column<Guid>(type: "uuid", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    DeletedBy = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SchoolPerformances", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_SchoolPerformances_Schools_SchoolId",
+                        column: x => x.SchoolId,
+                        principalSchema: "marks",
+                        principalTable: "Schools",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SchoolPerformances_IsDeleted",
+                schema: "marks",
+                table: "SchoolPerformances",
+                column: "IsDeleted");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SchoolPerformances_SchoolId_Year",
+                schema: "marks",
+                table: "SchoolPerformances",
+                columns: new[] { "SchoolId", "Year" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SchoolPerformances_Year",
+                schema: "marks",
+                table: "SchoolPerformances",
+                column: "Year");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Schools_DistrictName",
+                schema: "marks",
+                table: "Schools",
+                column: "DistrictName");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Schools_EmisNumber",
+                schema: "marks",
+                table: "Schools",
+                column: "EmisNumber",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Schools_IsDeleted",
+                schema: "marks",
+                table: "Schools",
+                column: "IsDeleted");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Schools_Province",
+                schema: "marks",
+                table: "Schools",
+                column: "Province");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "SchoolPerformances",
+                schema: "marks");
+
+            migrationBuilder.DropTable(
+                name: "Schools",
+                schema: "marks");
+        }
+    }
+}


### PR DESCRIPTION
# Description

Creates the database schema for matric (NSC) school performance data, replacing the current mock data foundation with real domain entities.

## Changes

### Domain Layer
- **School entity** — Province, DistrictName, EmisNumber (unique), CentreNumber, CentreName, Quintile. Extends `BaseEntity`.
- **SchoolPerformance entity** — Yearly NSC results: ProgressedNumber, TotalWrote, TotalAchieved, PercentAchieved. Unique constraint on `(SchoolId, Year)`.

### Infrastructure Layer
- EF Core configurations in the `marks` schema
- `DbSet<School>` and `DbSet<SchoolPerformance>` in `MatricDasbhoardDbContext`
- Migration `AddMatricMarksSchema` creating `marks.Schools` and `marks.SchoolPerformances` tables

### Data
The CSV file `2024_nsc_school_performance_report.csv` (6,922 rows) at the project root is the source dataset. Import mechanism will be implemented separately.

## Verification
- `dotnet build` — 0 errors
- `dotnet test` — Unit: 97/97 passed
- Architecture: 10/10 passed
- Component: 541/541 passed
- (API tests have pre-existing failures unrelated to these changes — missing `appsettings.Testing.json`)

## Related
- Closes MATRD-2
- Next: CSV data import + update `DashboardService` to use real EF queries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added database support for tracking matric marks and school performance data, including NSC examination results and yearly academic metrics.

* **Documentation**
  * Added documentation detailing the matric marks schema design and entity relationships.

* **Chores**
  * Updated tooling dependencies to latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->